### PR TITLE
This pull request adds database search functionality to killandmail for mmm accounts

### DIFF
--- a/killandmail
+++ b/killandmail
@@ -52,9 +52,15 @@ get_mail_address () {
       echo "Warning: this is a course account, and does not have a valid mail address.">&2
       echo "nobody@ucl.ac.uk"
   elif [[ "${username:0:3}" == "mmm" ]]; then
-      # If it becomes necessary we could put a database lookup here but it hasn't really been so far
-      echo "Warning: this is an external account, and does not have a valid mail address.">&2
-      echo "nobody@ucl.ac.uk"
+      # Do a database lookup and if this fails send to nobody.
+      email_search=$(mmm-to-email)
+      search_success=$?
+      if [[ "${search_success}" == "0" ]]; then
+        echo $email_search
+      else
+        echo "Warning: this is an external account, and does not have a valid mail address.">&2
+        echo "nobody@ucl.ac.uk"        
+      fi
   else
     echo "$1@ucl.ac.uk"
   fi

--- a/killandmail
+++ b/killandmail
@@ -20,6 +20,8 @@ elif [[ "$hostnamef" =~ grace.ucl.ac.uk ]]; then
   this_cluster="Grace"
 elif [[ "$hostnamef" =~ thomas.ucl.ac.uk ]]; then
   this_cluster="Thomas"
+elif [[ "$hostnamef" =~ michael.ucl.ac.uk ]]; then
+  this_cluster="Michael"
 elif [[ "$hostnamef" =~ myriad.ucl.ac.uk ]]; then
   this_cluster="Myriad"
 else

--- a/killandmail
+++ b/killandmail
@@ -55,7 +55,7 @@ get_mail_address () {
       echo "nobody@ucl.ac.uk"
   elif [[ "${username:0:3}" == "mmm" ]]; then
       # Do a database lookup and if this fails send to nobody.
-      email_search=$(mmm-to-email)
+      email_search=$(mmm-to-email $username)
       search_success=$?
       if [[ "${search_success}" == "0" ]]; then
         echo $email_search

--- a/mmm-to-email
+++ b/mmm-to-email
@@ -1,0 +1,16 @@
+#!/bin/bash 
+# wrapper for python3 script
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+        . /etc/bashrc
+fi
+
+module load gcc-libs
+module load python3/3.5
+module load mysql-connector-python/2.0.4/python-3.5.2
+
+# get script location
+DIR=$(dirname "$(readlink -f "$0")")
+$DIR/thomas/mmm_to_email.py "$@"
+

--- a/thomas/mmm_to_email.py
+++ b/thomas/mmm_to_email.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# A simple tool to convert mmm userids into an email address for killandmail.
+
+def getEmail(userid):
+    import mysql.connector
+    from mysql.connector import errorcode
+
+    email=""
+
+    query = "SELECT email FROM users WHERE username LIKE '" + userid + "';"
+
+    try:
+        conn = mysql.connector.connect(option_files=os.path.expanduser('~/.thomas.cnf'), database='thomas')
+        cursor = conn.cursor()
+
+        cursor.execute(query)
+        results=cursor.fetchall()
+
+        email = results[0][0]
+    
+    except mysql.connector.Error as err:
+        if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
+            print("Access denied: Something is wrong with your user name or password")
+        elif err.errno == errorcode.ER_BAD_DB_ERROR:
+            print("Database does not exist")
+        else:
+            print(err)
+    else:
+        cursor.close()
+        conn.close()
+
+    return email
+
+if __name__ == "__main__":
+    import sys
+    import os.path
+
+    if len(sys.argv) != 2:
+        print("Run with " + sys.argv[0] + " <userid>")
+        sys.exit(1)
+
+    if not(os.path.isfile(os.path.expanduser('~/.thomas.cnf'))):
+        print("Database connection not configured.")
+        sys.exit(2)
+
+    userid = sys.argv[1]
+
+    if not(userid.startswith("mmm") and (len(userid) == 7)):
+        print("Invalid userid.  Userid must be of the form mmmXXXX.")
+        sys.exit(3)
+
+    email = getEmail(userid)
+
+    if email != "":
+        print(email)
+    else:
+        sys.exit(10)
+
+    


### PR DESCRIPTION
We've had a couple of long running, parallel processor intensive tasks on the Thomas login nodes so I've added the ability for killandmail to search our MMM user database for a user's email so we can email users who are external when we kill their processes as we do with UCL ones.

This pull request consists of two parts:

1. `thomas/mmm_to_email.py` - this python script searches the database for a single username and prints out the matching email to `stdout`.  It uses the same database configuration as `thomas-show`.

2. Modifications to `killandmail` so that in the event of the process being killed being owned by a userid starting with `mmm` it tries to search the database and if it gets a 0 return code uses the results from the search.  Otherwise, as a failsafe it prints a warning and sends mail to `nobody@`.

I've also:

3. Added Michael to the cluster list.