### PR TITLE
lquota -u: fix double-counting

### DIFF
--- a/lquota
+++ b/lquota
@@ -122,8 +122,8 @@ function _get_user_quota_usage() {
             | awk '{print $2}'
     else
         lfs quota -v -q -u "$username" "$lustre_path" 2>/dev/null \
-            | grep '^\s\+[0-9]\+\*\?\s' \
-            | awk '{ sum+=$1 } END { print sum }'
+            | grep -A1 '^\w\+-\(MDT\|OST\)' \
+            | awk '/^\s*[0-9]+\*?\s/ { sum +=$1 } END { print sum }'
     fi
 }
 
@@ -161,8 +161,8 @@ function _get_project_quota_usage() {
             | awk '{print $2}'
     else
         lfs quota -v -q -p "$project_id" "$lustre_path" 2>/dev/null \
-            | grep '^\s\+[0-9]\+\*\?\s' \
-            | awk '{ sum+=$1 } END { print sum }'
+            | grep -A1 '^\w\+-\(MDT\|OST\)' \
+            | awk '/^\s+[0-9]+\*?\s/ { sum +=$1 } END { print sum }'
     fi
 }
 


### PR DESCRIPTION
Once quotas are enabled, `lquota -u` would double-count space
when the lustre path is so long that the summary information in
`lfs quota -v` is printed on a separate line. (Happens on myriad's
/scratch.)

Fix by more rigourously filtering for `lfs quota -v` output lines
that come from the individual MDTs/OSTs. Also incorporate @ikirker's
suggestion to combine the original `grep` and `awk` commands (but
with a small fix to the `awk` regexp).

Tested on Myriad, Kathleen, Michael, Young, and Thomas.