### PR TITLE
Implement new quota system for Kathleen

### DIFF
--- a/aquota
+++ b/aquota
@@ -62,14 +62,21 @@ username="${1:-"${USER:-}"}"
 userdir="${ACFSdir}/${username}"
 
 _timeout_guard mountpoint -q "${ACFSdir}" \
-|| error "ACFS is not mounted."
+   || error "ACFS is not mounted."
 
 _timeout_guard test -d "${userdir}" \
-|| error "ACFS directory '${userdir}' doesn't exist."
+   || error "ACFS directory '${userdir}' doesn't exist."
 
+
+# Note that:
+#  - this is intended to point at an NFS mount of a GPFS system
+#  - running df against one of those gives the *fileset quota* which we are using per-user
+#  - so this gives us the user's quota on ACFS, *not* the total available storage on the ACFS
+#  - ACFS has actual user (and group) quotas and we are not using them
+#  - yes, this is, overall, a little weird
 df_output="$( _timeout_guard df -k --output='size,used,pcent' "${userdir}" | tail -n 1 )"
 
-read bquota bused bpct <<< "${df_output}"
+read -r bquota bused bpct <<< "${df_output}"
 bquota="$(kiB_to_human "$(( bquota / repfac ))")"
 bused="$(kiB_to_human "$(( bused / repfac ))")"
 

--- a/aquota
+++ b/aquota
@@ -4,7 +4,9 @@
 # Display a users ACFS quota and disk usage.
 # -- 2024/08 uccafot
 
-set -o pipefail
+set -o errexit \
+    -o nounset \
+    -o pipefail
 
 usage () {
    local rc="$1"
@@ -53,8 +55,9 @@ while getopts ':h' opt; do
 done
 shift $((OPTIND-1))
 
-username="$1"
-[[ -z "$username" ]] && username="$USER"
+username="${1:-"${USER:-}"}"
+[[ -n "$username" ]] \
+   || error "cannot determine username to use: no argument provided and USER variable not set."
 
 userdir="${ACFSdir}/${username}"
 
@@ -65,9 +68,6 @@ _timeout_guard test -d "${userdir}" \
 || error "ACFS directory '${userdir}' doesn't exist."
 
 df_output="$( _timeout_guard df -k --output='size,used,pcent' "${userdir}" | tail -n 1 )"
-# here, the timeout guard runs in a subshell, so it won't exit this script
-rc=$?
-[[ "$rc" -ne 0 ]] && exit "$rc"
 
 read bquota bused bpct <<< "${df_output}"
 bquota="$(kiB_to_human "$(( bquota / repfac ))")"

--- a/aquota
+++ b/aquota
@@ -1,0 +1,79 @@
+#!/bin/bash
+# vim: set et ai sw=3 ts=3 :
+
+# Display a users ACFS quota and disk usage.
+# -- 2024/08 uccafot
+
+set -o pipefail
+
+usage () {
+   local rc="$1"
+   [[ -z "$rc" ]] && rc=1
+   cat <<EOF
+Usage: aquota [ <username> ]
+Display the user's ACFS quota and disk usage.
+Without username, defaults to the current user.
+EOF
+   exit "$rc"
+}
+
+error () {
+   local msg="$1"
+   echo "ERROR: ${msg}" >&2
+   exit 1
+}
+
+_timeout_guard () {
+   timeout -k 3 5 "$@"
+   rc=$?
+   [[ "$rc" -eq 124 ]] && error "Command timed out. Server unavailable?"
+   return "$rc"
+}
+
+kiB_to_human () {
+   local size="$1"
+   # RHEL7 numfmt doesn't support precision control :(
+   numfmt --from=iec-i --to=iec-i --suffix B "${size}KiB"
+}
+
+# GPFS reports quota and usage as the actually allocated disk space,
+# i.e. including the replication factor (2, for us). For the whole
+# saga, see https://github.com/UCL-ARC/Book-of-RDP/issues/96
+repfac=2
+
+# ACFS mount point
+ACFSdir='/acfs/users'
+
+
+while getopts ':h' opt; do
+   case "$opt" in
+      h)  usage 0 ;;
+      *)  error "invalid option: $OPTARG" ;;
+   esac
+done
+shift $((OPTIND-1))
+
+username="$1"
+[[ -z "$username" ]] && username="$USER"
+
+userdir="${ACFSdir}/${username}"
+
+_timeout_guard mountpoint -q "${ACFSdir}" \
+|| error "ACFS is not mounted."
+
+_timeout_guard test -d "${userdir}" \
+|| error "ACFS directory '${userdir}' doesn't exist."
+
+df_output="$( _timeout_guard df -k --output='size,used,pcent' "${userdir}" | tail -n 1 )"
+# here, the timeout guard runs in a subshell, so it won't exit this script
+rc=$?
+[[ "$rc" -ne 0 ]] && exit "$rc"
+
+read bquota bused bpct <<< "${df_output}"
+bquota="$(kiB_to_human "$(( bquota / repfac ))")"
+bused="$(kiB_to_human "$(( bused / repfac ))")"
+
+printf "%-20s %7s %7s %6s\n" \
+   "Path" "Used" "Quota" "%Used"
+printf "%-20s %7s %7s %6s\n" \
+   "$userdir" "$bused" "$bquota" "$bpct"

--- a/lquota
+++ b/lquota
@@ -211,7 +211,11 @@ function print_user_quota_for_poolkvs() {
 
           human_usage="$(raw_kb_to_human_size "$usage_kb")"
           human_quota="$(raw_kb_to_human_size "$quota_kb")"
-          usage_pc="$(( (usage_kb * 100) / quota_kb ))"
+          if [[ "$quota_kb" -gt 0 ]]; then
+              usage_pc="$(( (usage_kb * 100) / quota_kb ))"
+          else
+              usage_pc=0  # no quota, which means unlimited
+          fi
 
           printf "%*s  %*s   %*s   %5d%%   %s\n" 12 "$pool_name" 10 "$human_usage" 10 "$human_quota" "$usage_pc" "$pool_path"
           if [[ "$usage_pc" -ge 90 ]] && [[ "$usage_pc" -le 100 ]]; then
@@ -289,7 +293,11 @@ function print_project_quota_for_poolkvs() {
 
           human_usage="$(raw_kb_to_human_size "$usage_kb")"
           human_quota="$(raw_kb_to_human_size "$quota_kb")"
-          usage_pc="$(( (usage_kb * 100) / quota_kb ))"
+          if [[ "$quota_kb" -gt 0 ]]; then
+              usage_pc="$(( (usage_kb * 100) / quota_kb ))"
+          else
+              usage_pc=0  # no quota, which means unlimited
+          fi
 
           printf "%*s  %*s   %*s   %5d%%   %s\n" 12 "$pool_name" 10 "$human_usage" 10 "$human_quota" "$usage_pc" "$pool_path"
           if [[ "$usage_pc" -ge 90 ]] && [[ "$usage_pc" -le 100 ]]; then

--- a/lquota
+++ b/lquota
@@ -127,17 +127,24 @@ function _get_user_quota_usage() {
     fi
 }
 
-function _get_project_quota() {
+function _get_project_id() {
+    local lustre_path="$1"
+
     command -v lsattr >/dev/null \
         || msg fatal "could not find lsattr command, needed for project quota ID"
 
+    local project_id
+          project_id="$(lsattr -pd "$lustre_path" | awk '{print $1}' \
+                            || msg fatal "lsattr command could not get project ID"
+                       )"
+    echo "$project_id"
+}
+
+function _get_project_quota() {
     local lustre_path="$1"
 
     local project_id
-    project_id="$(lsattr -pd "$lustre_path" \
-                    || msg fatal "lsattr command could not get project ID"
-                )"
-    project_id="${project_id%% *}"
+          project_id="$(_get_project_id "$lustre_path")"
 
     lfs quota -q -p "$project_id" "$lustre_path" \
         | tr -d '\n*' \
@@ -145,16 +152,10 @@ function _get_project_quota() {
 }
 
 function _get_project_quota_usage() {
-    command -v lsattr >/dev/null \
-        || msg fatal "could not find lsattr command, needed for project quota ID"
-
     local lustre_path="$1"
 
     local project_id
-          project_id="$(lsattr -pd "$lustre_path" \
-                            || msg fatal "lsattr command could not get project ID"
-                       )"
-          project_id="${project_id%% *}"
+          project_id="$(_get_project_id "$lustre_path")"
 
     if [[ -z "$global_calc_usage" ]]; then
         lfs quota -q -p "$project_id" "$lustre_path" \
@@ -382,10 +383,7 @@ function report_project_quota() {
             msg debug "skipping entry '${userdir}', malformed username"
             continue
         fi
-        project_id="$(lsattr -pd "${userdir}" \
-                      || msg fatal "lsattr command could not get project ID"
-                     )"
-        project_id="${project_id%% *}"
+        project_id="$(_get_project_id "${userdir}")"
         if [[ "${project_id}" -eq 0 ]]; then
             msg debug "skipping entry '${userdir}', project id is zero"
             continue
@@ -639,15 +637,15 @@ function __main() {
             ;;
         "kathleen")
             msg debug "using settings for kathleen"
-            # Whereas Kathleen uses ZFS on the backend storage,
-            #  which doesn't support project attributes on files C_C
-            local quota_mode="user"
+            # Kathleen's new Lustre uses project quotas,
+            # but no separate quotas for home and scratch
+            local quota_mode="project"
             local -A pools=([lustre]="/home/%username%")
             local default_pool="lustre"
             ;;
         "young")
             msg debug "using settings for young"
-            # ZFS, no project attributes, one single quota
+            # Young's Lustre uses ZFS which didn't support project quotas initially
             local quota_mode="user"
             local -A pools=([lustre]="/home/%username%")
             local default_pool="lustre"


### PR DESCRIPTION
Kathleen's new Lustre supports project quotas, so we'll use that instead of user quotas.
`lquota` changed accordingly, plus some minor fixes.